### PR TITLE
Implement RADIUS salt en- and decryption

### DIFF
--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -131,9 +131,9 @@ pub fn encrypt_data(data: &str, authenticator: &[u8], secret: &[u8]) -> Vec<u8> 
     if missing_length != 0 {
         data_buffer.append(&mut vec![0u8; 16 - missing_length]);
     }
-    
+
     let mut result = Vec::with_capacity(data_buffer.len());
-    
+
     while !data_buffer.is_empty() {
         let mut temp = secret.to_vec();
         temp.append(&mut prev_result.to_vec());
@@ -150,12 +150,12 @@ pub fn encrypt_data(data: &str, authenticator: &[u8], secret: &[u8]) -> Vec<u8> 
         prev_result = result[(result.len() - 16)..].to_vec();
         data_buffer = data_buffer[16..].to_vec();
     }
-    result   
+    result
 }
 
 /// Decrypts data since RADIUS packet is sent in plain text
 pub fn decrypt_data(data: &[u8], authenticator: &[u8], secret: &[u8]) -> Vec<u8> {
-    /* 
+    /*
      * To decrypt the data, we need to apply the same algorithm as in encrypt_data()
      * but with small change
      *
@@ -177,7 +177,7 @@ pub fn decrypt_data(data: &[u8], authenticator: &[u8], secret: &[u8]) -> Vec<u8>
         let mut hash = [0; 16];
         md5.input(&temp);
         md5.result(&mut hash);
-        
+
         for i in 0..16 {
             result.push(hash[i] ^ data_buffer[i]);
         }
@@ -190,6 +190,95 @@ pub fn decrypt_data(data: &[u8], authenticator: &[u8], secret: &[u8]) -> Vec<u8>
     }
     result
 }
+
+/// Encrypt data for a salt encrypted RADIUS Attribute (e.g. Tunnel-Password)
+pub fn salt_encrypt(data: &[u8], authenticator: &[u8], salt: &[u8], secret: &[u8]) -> Vec<u8> {
+    if data.len() == 0 {
+        return Vec::new();
+    }
+    let mut hash = [0u8; 16];
+    // make buffer big enough be fit the salt + encrypted data
+    let padding = ((-(data.len() as isize + 1)) & 15) as usize;
+    let mut result = Vec::with_capacity(data.len() + 3 + padding);
+    result.extend_from_slice(salt);
+    result.push(data.len() as u8);
+    result.extend_from_slice(data);
+    result.extend_from_slice(&hash[..padding]);
+
+    let salted_authenticator = &mut [0u8; 18];
+    salted_authenticator[..16].copy_from_slice(authenticator);
+    salted_authenticator[16..].copy_from_slice(salt);
+
+    let mut prev = &salted_authenticator[..];
+    let mut current = &mut result[2..];
+
+    loop {
+        let mut md5 = Md5::new();
+        md5.input(secret);
+        md5.input(prev);
+        md5.result(&mut hash);
+
+        for (d, h) in current.iter_mut().zip(hash.iter()) {
+            *d ^= *h
+        }
+
+        let (p, c) = current.split_at_mut(16);
+        prev = p;
+        current = c;
+        if current.len() == 0 { break }
+    }
+
+    result
+}
+
+
+/// Decrypts a salt encrypted RADIUS Attribute (e.g. Tunnel-Password)
+pub fn salt_decrypt_data(data: &[u8], authenticator: &[u8], secret: &[u8]) -> Result<Vec<u8>, RadiusError> {
+    /*
+     * The salt decryption, behaves almost the same as normal Password encryption in RADIUS. The
+     * main difference is the presence of a two byte salt, which is appended to the authenticator
+     *
+     */
+    if data.len() <= 1 {
+        return Err(RadiusError::MalformedAttributeError {error: "salt encrypted attribute too short".to_string()});
+    }
+    if data.len() <= 3 {
+        // There is a Salt or there is a salt + datalen: Both cases mean "Password is empty"
+        return Ok(Vec::new());
+    }
+    let salted_authenticator = &mut [0u8; 18];
+    salted_authenticator[..16].copy_from_slice(authenticator);
+    salted_authenticator[16..].copy_from_slice(&data[..2]);
+
+    let mut result = Vec::with_capacity(data.len()-2);
+    let mut prev = &salted_authenticator[..];
+
+    let mut hash = [0u8; 16];
+    for data_chunk in (&data[2..]).chunks_exact(16) {
+        let mut md5 = Md5::new();
+        md5.input(secret);
+        md5.input(prev);
+        md5.result(&mut hash);
+
+
+        for (d, h) in data_chunk.iter().zip(hash.iter_mut()) {
+            *h ^= d
+        }
+        result.extend_from_slice(&hash);
+
+        prev = data_chunk;
+    }
+
+    let target_len = usize::from(result.remove(0));
+
+    if target_len > data.len() - 3 {
+        return Err(RadiusError::MalformedAttributeError { error: "Tunnel Password too long (shared secret might be wrong)".to_string()});
+    }
+    result.truncate(target_len);
+
+    Ok(result)
+}
+
 
 // -----------------------------------------
 fn u16_to_be_bytes(u16_data: u16) -> [u8;2] {
@@ -268,6 +357,48 @@ mod tests {
         let decrypted_data = decrypt_data(&encrypted_data, &authenticator, &secret.as_bytes());
 
         assert_eq!(expected_data.as_bytes().to_vec(), decrypted_data);
+    }
+
+    #[test]
+    fn test_salt_encrypt_data() {
+        let secret = b"secret";
+        let authenticator: &[u8] = &[0u8; 16];
+
+        let plaintext = b"password";
+        let encrypted_data: &[u8] = &[0x85, 0x9a, 0xe3, 0x88, 0x34, 0x49, 0xf2, 0x1e, 0x14, 0x4c, 0x76, 0xc8, 0xb2, 0x1a, 0x1d, 0x4f, 0x0c, 0xdc];
+        let salt = &encrypted_data[..2];
+
+        assert_eq!(encrypted_data, salt_encrypt(plaintext, authenticator, salt, secret).as_slice());
+
+        let plaintext_long = b"a very long password, which will need multiple iterations";
+        let encrypted_data_long: &[u8] = &[0x85, 0xd9, 0x61, 0x72, 0x75, 0x37, 0xcf, 0x15, 0x20,
+        0x19, 0x3b, 0x38, 0x39, 0x0e, 0x42, 0x21, 0x9b, 0x5e, 0xcb, 0x93, 0x25, 0x7d, 0xb4, 0x07,
+        0x0c, 0xc1, 0x52, 0xcf, 0x38, 0x76, 0x29, 0x02, 0xc7, 0xb1, 0x29, 0xdf, 0x63, 0x96, 0x26,
+        0x1a, 0x27, 0xe5, 0xc3, 0x13, 0x78, 0xa7, 0x97, 0xd8, 0x97, 0x9a, 0x45, 0xc3, 0x70, 0xd3,
+        0xe4, 0xe2, 0xae, 0xd0, 0x55, 0x77, 0x19, 0xa5, 0xb6, 0x44, 0xe6, 0x8a];
+        let salt = &encrypted_data_long[..2];
+
+        assert_eq!(encrypted_data_long, salt_encrypt(plaintext_long, authenticator, salt, secret).as_slice());
+    }
+
+    #[test]
+    fn test_salt_decrypt_data() {
+        let secret = b"secret";
+        let authenticator: &[u8] = &[0u8; 16];
+
+        let plaintext: &[u8] = b"password";
+        let encrypted_data: &[u8] = &[0x85, 0x9a, 0xe3, 0x88, 0x34, 0x49, 0xf2, 0x1e, 0x14, 0x4c, 0x76, 0xc8, 0xb2, 0x1a, 0x1d, 0x4f, 0x0c, 0xdc];
+
+        assert_eq!(plaintext, salt_decrypt_data(encrypted_data, authenticator, secret).unwrap().as_slice());
+
+        let plaintext_long = b"a very long password, which will need multiple iterations";
+        let encrypted_data_long: &[u8] = &[0x85, 0xd9, 0x61, 0x72, 0x75, 0x37, 0xcf, 0x15, 0x20,
+        0x19, 0x3b, 0x38, 0x39, 0x0e, 0x42, 0x21, 0x9b, 0x5e, 0xcb, 0x93, 0x25, 0x7d, 0xb4, 0x07,
+        0x0c, 0xc1, 0x52, 0xcf, 0x38, 0x76, 0x29, 0x02, 0xc7, 0xb1, 0x29, 0xdf, 0x63, 0x96, 0x26,
+        0x1a, 0x27, 0xe5, 0xc3, 0x13, 0x78, 0xa7, 0x97, 0xd8, 0x97, 0x9a, 0x45, 0xc3, 0x70, 0xd3,
+        0xe4, 0xe2, 0xae, 0xd0, 0x55, 0x77, 0x19, 0xa5, 0xb6, 0x44, 0xe6, 0x8a];
+
+        assert_eq!(plaintext_long, salt_decrypt_data(encrypted_data_long, authenticator, secret).unwrap().as_slice());
     }
 
     #[test]


### PR DESCRIPTION
This commit implement utility function for encrypting and decrypting
salt encrypted RADIUS Attributes.

The data for the testcases were generated with the freeradius tool
"radclient".

The encryption and decryption functions have asymmetric parameters. The
salt for the decryption function is read from the encoded attribute
itself.

Generation of the salt for the encryption cannot be automated. RFC 2828
mandates that the salt of the encrypted Tunnel-Password attribute has
the most significant bit set to 1. The Draft
draft-ietf-radius-saltencrypt-00 requires that the most significant bit
is set to 1 for responses type packets and to 0 for request type
packets. Since this information is not available to the encrypt function
the caller has to pass a salt explicitly.

RFC 2828 suggest to pad the salt encrypted value with zeros, which is
done in this implementation. This differs from the Freeradius
implementation (which was used as a reference) where the padding was
filled with random data.