### PR TITLE
fix: the RADIUS date datetype is 32-bit per standard

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -184,7 +184,7 @@ impl Client {
 
     /// Generates HMAC-MD5 hash for Message-Authenticator attribute
     ///
-    /// Note: this function assumes that RadiusAttribute Message-Authenticator already exists in RadiusPacket 
+    /// Note: this function assumes that RadiusAttribute Message-Authenticator already exists in RadiusPacket
     pub fn generate_message_hash(&self, packet: &mut RadiusPacket) -> Vec<u8> {
         // Feels redundant, but let it be for now
         let mut hash = Hmac::new(Md5::new(), self.secret.as_bytes());
@@ -204,7 +204,7 @@ impl Client {
     /// Gets the original value as an Integer
     ///
     /// If the RadiusAttribute respresents dictionary attribute of type: integer or date
-    pub fn radius_attr_original_integer_value(&self, attribute: &RadiusAttribute) -> Result<u64, RadiusError> {
+    pub fn radius_attr_original_integer_value(&self, attribute: &RadiusAttribute) -> Result<u32, RadiusError> {
         let dict_attr = self.host.dictionary_attribute_by_id(attribute.id()).ok_or_else(|| RadiusError::MalformedAttributeError {error: format!("No attribute with ID: {} found in dictionary", attribute.id())} )?;
         attribute.original_integer_value(dict_attr.code_type())
     }

--- a/src/protocol/dictionary.rs
+++ b/src/protocol/dictionary.rs
@@ -14,7 +14,7 @@ pub enum SupportedAttributeTypes {
     AsciiString,
     /// Rust's u32
     Integer,
-    /// Rust's u64
+    /// Rust's u32
     Date,
     /// Rust's \[u8;4\]
     IPv4Addr,
@@ -205,7 +205,7 @@ mod tests {
             name:        "User-Name".to_string(),
             vendor_name: "".to_string(),
             code:        "1".to_string(),
-            code_type:   Some(SupportedAttributeTypes::AsciiString) 
+            code_type:   Some(SupportedAttributeTypes::AsciiString)
         });
         attributes.push(DictionaryAttribute {
             name:        "NAS-IP-Address".to_string(),
@@ -243,7 +243,7 @@ mod tests {
             code:        "25".to_string(),
             code_type:   Some(SupportedAttributeTypes::IPv4Addr)
         });
-        
+
         let mut values: Vec<DictionaryValue> = Vec::new();
         values.push(DictionaryValue {
             attribute_name: "Framed-Protocol".to_string(),

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -105,9 +105,10 @@ pub fn timestamp_to_bytes(timestamp: u64) -> Vec<u8> {
 }
 
 /// Converts timestamp bytes into u64
-pub fn bytes_to_timestamp(timestamp: &[u8; 8]) -> u64 {
-    u64::from_be_bytes(*timestamp)
+pub fn bytes_to_timestamp(timestamp: &[u8; 4]) -> u32 {
+    u32::from_be_bytes(*timestamp)
 }
+
 
 /// Encrypts data since RADIUS packet is sent in plain text
 ///
@@ -144,7 +145,7 @@ pub fn encrypt_data(data: &[u8], authenticator: &[u8], secret: &[u8]) -> Vec<u8>
 /// Should be used to decrypt value of **User-Password** attribute (but could also be used to
 /// decrypt any data)
 pub fn decrypt_data(data: &[u8], authenticator: &[u8], secret: &[u8]) -> Vec<u8> {
-    /* 
+    /*
      * To decrypt the data, we need to apply the same algorithm as in encrypt_data()
      * but with small change
      *
@@ -514,7 +515,7 @@ mod tests {
 
     #[test]
     fn test_bytes_to_timestamp() {
-        let timestamp_bytes = [0, 0, 0, 0, 95, 71, 138, 29];
+        let timestamp_bytes = [95, 71, 138, 29];
 
         assert_eq!(1598523933, bytes_to_timestamp(&timestamp_bytes));
     }


### PR DESCRIPTION
The previous implementation of the date datatype expected it
to be 64-bit. This changes all 64-bit dates to 32-bit.

This partially affects some functions which are used for the integer datatype. For some reason they were 64-bit too, while the integer datatype is 32-bit as well.