### PR TITLE
Update dictionary.rs

### DIFF
--- a/src/protocol/dictionary.rs
+++ b/src/protocol/dictionary.rs
@@ -123,7 +123,7 @@ impl Dictionary {
             .filter(|line| !line.contains(&COMMENT_PREFIX));
 
         for line in lines {
-            let parsed_line: Vec<&str> = line.split(" ").filter(|&item| !item.is_empty()).collect();
+            let parsed_line: Vec<&str> = line.split_whitespace().filter(|&item| !item.is_empty()).collect();
             match parsed_line[0] {
                 "ATTRIBUTE"    => parse_attribute(parsed_line, &vendor_name, &mut attributes),
                 "VALUE"        => parse_value(parsed_line, &vendor_name, &mut values),


### PR DESCRIPTION
Allow tabs as well as spaces in dictionary files.

E.g. the /etc/radcli/dictionary in libradcli4 package on debian, which I intend to use, uses tabs.  Without this change, the client claims not to know about the "User-Name" ATTRIBUTE.  With it, things work fine.

Thanks,
Alex