### PR TITLE
Correct spelling: initialise -> initialize

### DIFF
--- a/benches/async_client_2_server.rs
+++ b/benches/async_client_2_server.rs
@@ -24,7 +24,7 @@ struct ClientWrapper {
 }
 
 impl ClientWrapper {
-    fn initialise_client(auth_port: u16, acct_port: u16, coa_port: u16, dictionary: Dictionary, server: String, secret: String, retries: u16, timeout: u16) -> Result<ClientWrapper, RadiusError> {
+    fn initialize_client(auth_port: u16, acct_port: u16, coa_port: u16, dictionary: Dictionary, server: String, secret: String, retries: u16, timeout: u16) -> Result<ClientWrapper, RadiusError> {
         // Bind socket
         let socket = task::block_on(UdpSocket::bind("0.0.0.0:0")).map_err(|error| RadiusError::SocketConnectionError(error))?;
         // --------------------
@@ -101,7 +101,7 @@ impl AsyncClientTrait for ClientWrapper {
 #[bench]
 fn test_async_auth_client_wo_response_against_server(b: &mut Bencher) {
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-    let client     = ClientWrapper::initialise_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
+    let client     = ClientWrapper::initialize_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
 
     let user_name            = String::from("testing").into_bytes();
     let user_pass            = b"very secure password, that noone is able to guess";
@@ -131,7 +131,7 @@ fn test_async_auth_client_wo_response_against_server(b: &mut Bencher) {
 #[bench]
 fn test_async_auth_client_w_response_against_server(b: &mut Bencher) {
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-    let client     = ClientWrapper::initialise_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
+    let client     = ClientWrapper::initialize_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
 
     let user_name            = String::from("testing").into_bytes();
     let user_pass            = b"very secure password, that noone is able to guess";
@@ -164,7 +164,7 @@ fn test_async_auth_client_w_response_against_server(b: &mut Bencher) {
 #[bench]
 fn test_async_acct_client_wo_response_against_server(b: &mut Bencher) {
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-    let client     = ClientWrapper::initialise_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
+    let client     = ClientWrapper::initialize_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
 
     let user_name            = String::from("testing").into_bytes();
     let user_pass            = b"very secure password, that noone is able to guess";
@@ -194,7 +194,7 @@ fn test_async_acct_client_wo_response_against_server(b: &mut Bencher) {
 #[bench]
 fn test_async_acct_client_w_response_against_server(b: &mut Bencher) {
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-    let client     = ClientWrapper::initialise_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
+    let client     = ClientWrapper::initialize_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
 
     let user_name            = String::from("testing").into_bytes();
     let user_pass            = b"very secure password, that noone is able to guess";
@@ -227,7 +227,7 @@ fn test_async_acct_client_w_response_against_server(b: &mut Bencher) {
 #[bench]
 fn test_async_coa_client_wo_response_against_server(b: &mut Bencher) {
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-    let client     = ClientWrapper::initialise_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
+    let client     = ClientWrapper::initialize_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
 
     let user_name            = String::from("testing").into_bytes();
     let user_pass            = b"very secure password, that noone is able to guess";
@@ -257,7 +257,7 @@ fn test_async_coa_client_wo_response_against_server(b: &mut Bencher) {
 #[bench]
 fn test_async_coa_client_w_response_against_server(b: &mut Bencher) {
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-    let client     = ClientWrapper::initialise_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
+    let client     = ClientWrapper::initialize_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
 
     let user_name            = String::from("testing").into_bytes();
     let user_pass            = b"very secure password, that noone is able to guess";

--- a/benches/sync_client_2_server.rs
+++ b/benches/sync_client_2_server.rs
@@ -26,7 +26,7 @@ struct ClientWrapper {
 impl ClientWrapper {
     const TOKEN: Token = Token(0);
 
-    fn initialise_client(auth_port: u16, acct_port: u16, coa_port: u16, dictionary: Dictionary, server: String, secret: String, retries: u16, timeout: u16) -> Result<ClientWrapper, RadiusError> {
+    fn initialize_client(auth_port: u16, acct_port: u16, coa_port: u16, dictionary: Dictionary, server: String, secret: String, retries: u16, timeout: u16) -> Result<ClientWrapper, RadiusError> {
         // Bind socket
         let local_bind  = "0.0.0.0:0".parse().map_err(|error| RadiusError::SocketAddrParseError(error))?;
         let mut socket  = UdpSocket::bind(local_bind).map_err(|error| RadiusError::SocketConnectionError(error))?;
@@ -126,7 +126,7 @@ impl SyncClientTrait for ClientWrapper {
 #[bench]
 fn test_auth_client_wo_response_against_server(b: &mut Bencher) {
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-    let mut client = ClientWrapper::initialise_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
+    let mut client = ClientWrapper::initialize_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
 
     let user_name            = String::from("testing").into_bytes();
     let user_pass            = b"very secure password, that noone is able to guess";
@@ -154,7 +154,7 @@ fn test_auth_client_wo_response_against_server(b: &mut Bencher) {
 #[bench]
 fn test_auth_client_w_response_against_server(b: &mut Bencher) {
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-    let mut client = ClientWrapper::initialise_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
+    let mut client = ClientWrapper::initialize_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
 
     let user_name            = String::from("testing").into_bytes();
     let user_pass            = b"very secure password, that noone is able to guess";
@@ -185,7 +185,7 @@ fn test_auth_client_w_response_against_server(b: &mut Bencher) {
 #[bench]
 fn test_acct_client_wo_response_against_server(b: &mut Bencher) {
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-    let mut client = ClientWrapper::initialise_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
+    let mut client = ClientWrapper::initialize_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
 
     let user_name            = String::from("testing").into_bytes();
     let user_pass            = b"very secure password, that noone is able to guess";
@@ -213,7 +213,7 @@ fn test_acct_client_wo_response_against_server(b: &mut Bencher) {
 #[bench]
 fn test_acct_client_w_response_against_server(b: &mut Bencher) {
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-    let mut client = ClientWrapper::initialise_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
+    let mut client = ClientWrapper::initialize_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
 
     let user_name            = String::from("testing").into_bytes();
     let user_pass            = b"very secure password, that noone is able to guess";
@@ -244,7 +244,7 @@ fn test_acct_client_w_response_against_server(b: &mut Bencher) {
 #[bench]
 fn test_coa_client_wo_response_against_server(b: &mut Bencher) {
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-    let mut client = ClientWrapper::initialise_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
+    let mut client = ClientWrapper::initialize_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
 
     let user_name            = String::from("testing").into_bytes();
     let user_pass            = b"very secure password, that noone is able to guess";
@@ -272,7 +272,7 @@ fn test_coa_client_wo_response_against_server(b: &mut Bencher) {
 #[bench]
 fn test_coa_client_w_response_against_server(b: &mut Bencher) {
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-    let mut client = ClientWrapper::initialise_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
+    let mut client = ClientWrapper::initialize_client(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).unwrap();
 
     let user_name            = String::from("testing").into_bytes();
     let user_pass            = b"very secure password, that noone is able to guess";

--- a/examples/async_radius_client.rs
+++ b/examples/async_radius_client.rs
@@ -26,7 +26,7 @@ struct ClientWrapper {
 }
 
 impl ClientWrapper {
-    async fn initialise_client(auth_port: u16, dictionary: Dictionary, server: String, secret: String, retries: u16, timeout: u16) -> Result<ClientWrapper, RadiusError> {
+    async fn initialize_client(auth_port: u16, dictionary: Dictionary, server: String, secret: String, retries: u16, timeout: u16) -> Result<ClientWrapper, RadiusError> {
         // Bind socket
         let socket = UdpSocket::bind("0.0.0.0:0").await.map_err(|error| RadiusError::SocketConnectionError(error))?;
         // --------------------
@@ -81,7 +81,7 @@ fn main() -> Result<(), RadiusError> {
     
     task::block_on(async {
         let dictionary = Dictionary::from_file("./dict_examples/integration_dict")?;
-        let client     = ClientWrapper::initialise_client(1812, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).await?;
+        let client     = ClientWrapper::initialize_client(1812, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2).await?;
 
         let user_name            = String::from("testing").into_bytes();
         let user_pass            = b"very secure password, that noone is able to guess";

--- a/examples/async_radius_server.rs
+++ b/examples/async_radius_server.rs
@@ -34,7 +34,7 @@ struct CustomServer {
 }
 
 impl CustomServer {
-    async fn initialise_server(auth_port: u16, acct_port: u16, coa_port: u16, dictionary: Dictionary, server: String, secret: String, retries: u16, timeout: u16, allowed_hosts: Vec<String>) -> Result<CustomServer, RadiusError> {
+    async fn initialize_server(auth_port: u16, acct_port: u16, coa_port: u16, dictionary: Dictionary, server: String, secret: String, retries: u16, timeout: u16, allowed_hosts: Vec<String>) -> Result<CustomServer, RadiusError> {
         // Initialise sockets
         let auth_socket = UdpSocket::bind(format!("{}:{}", &server, auth_port)).await?;
         let acct_socket = UdpSocket::bind(format!("{}:{}", &server, acct_port)).await?;
@@ -181,7 +181,7 @@ fn main() -> Result<(), RadiusError> {
     task::block_on(async {
         let dictionary    = Dictionary::from_file("./dict_examples/integration_dict").expect("Failed to load or parse file");
         let allowed_hosts = vec![String::from("127.0.0.1")];
-        let mut server    = CustomServer::initialise_server(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2, allowed_hosts).await.expect("Failed to create RADIUS Server");
+        let mut server    = CustomServer::initialize_server(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2, allowed_hosts).await.expect("Failed to create RADIUS Server");
 
         server.run().await
     })

--- a/examples/sync_radius_client.rs
+++ b/examples/sync_radius_client.rs
@@ -28,7 +28,7 @@ struct ClientWrapper {
 impl ClientWrapper {
     const TOKEN: Token = Token(0);
 
-    fn initialise_client(auth_port: u16, dictionary: Dictionary, server: String, secret: String, retries: u16, timeout: u16) -> Result<ClientWrapper, RadiusError> {
+    fn initialize_client(auth_port: u16, dictionary: Dictionary, server: String, secret: String, retries: u16, timeout: u16) -> Result<ClientWrapper, RadiusError> {
         // Bind socket
         let local_bind  = "0.0.0.0:0".parse().map_err(|error| RadiusError::SocketAddrParseError(error))?;
         let mut socket  = UdpSocket::bind(local_bind).map_err(|error| RadiusError::SocketConnectionError(error))?;
@@ -94,7 +94,7 @@ fn main() -> Result<(), RadiusError> {
     debug!("RADIUS Client started");
     
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict")?;
-    let mut client = ClientWrapper::initialise_client(1812, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2)?;
+    let mut client = ClientWrapper::initialize_client(1812, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2)?;
 
     let user_name             = String::from("testing").into_bytes();
     let message_authenticator = [0; 16];

--- a/examples/sync_radius_server.rs
+++ b/examples/sync_radius_server.rs
@@ -34,7 +34,7 @@ impl CustomServer {
     /// Exists to allow mapping between CoA socket and CoA requests processing
     pub const COA_SOCKET:  Token = Token(3);
 
-    fn initialise_server(auth_port: u16, acct_port: u16, coa_port: u16, dictionary: Dictionary, server: String, secret: String, retries: u16, timeout: u16, allowed_hosts: Vec<String>) -> Result<CustomServer, RadiusError> {
+    fn initialize_server(auth_port: u16, acct_port: u16, coa_port: u16, dictionary: Dictionary, server: String, secret: String, retries: u16, timeout: u16, allowed_hosts: Vec<String>) -> Result<CustomServer, RadiusError> {
         let auth_bind_addr = format!("{}:{}", &server, auth_port).parse().map_err(|error| RadiusError::SocketAddrParseError(error))?;
         let acct_bind_addr = format!("{}:{}", &server, acct_port).parse().map_err(|error| RadiusError::SocketAddrParseError(error))?;
         let coa_bind_addr  = format!("{}:{}", &server, coa_port).parse().map_err(|error| RadiusError::SocketAddrParseError(error))?;
@@ -60,9 +60,9 @@ impl CustomServer {
         socket_poll.registry().register(&mut acct_server, CustomServer::ACCT_SOCKET, Interest::READABLE)?;
         socket_poll.registry().register(&mut coa_server,  CustomServer::COA_SOCKET,  Interest::READABLE)?;
 
-        debug!("Authentication is initialised to accepts RADIUS packets on {}", &auth_server.local_addr()?);
-        debug!("Accounting is initialised to accepts RADIUS packets on {}",     &acct_server.local_addr()?);
-        debug!("CoA is initialised to accepts RADIUS packets on {}",            &coa_server.local_addr()?);
+        debug!("Authentication is initialized to accepts RADIUS packets on {}", &auth_server.local_addr()?);
+        debug!("Accounting is initialized to accepts RADIUS packets on {}",     &acct_server.local_addr()?);
+        debug!("CoA is initialized to accepts RADIUS packets on {}",            &coa_server.local_addr()?);
         // ============
 
         Ok(
@@ -213,7 +213,7 @@ fn main() -> Result<(), RadiusError> {
     debug!("RADIUS Server started");
 
     let dictionary = Dictionary::from_file("./dict_examples/integration_dict")?;
-    let mut server = CustomServer::initialise_server(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2, vec![String::from("127.0.0.1")])?;
+    let mut server = CustomServer::initialize_server(1812, 1813, 3799, dictionary, String::from("127.0.0.1"), String::from("secret"), 1, 2, vec![String::from("127.0.0.1")])?;
 
     server.run()
 }

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -110,28 +110,28 @@ impl Client {
     ///
     /// You would need to set attributes manually via *set_attributes()* function
     pub fn create_packet(&self, code: TypeCode) -> RadiusPacket {
-        RadiusPacket::initialise_packet(code)
+        RadiusPacket::initialize_packet(code)
     }
 
     /// Creates RADIUS Access Request packet
     ///
     /// You would need to set attributes manually via *set_attributes()* function
     pub fn create_auth_packet(&self) -> RadiusPacket {
-        RadiusPacket::initialise_packet(TypeCode::AccessRequest)
+        RadiusPacket::initialize_packet(TypeCode::AccessRequest)
     }
 
     /// Creates RADIUS Accounting Request packet without attributes
     ///
     /// You would need to set attributes manually via *set_attributes()* function
     pub fn create_acct_packet(&self) -> RadiusPacket {
-        RadiusPacket::initialise_packet(TypeCode::AccountingRequest)
+        RadiusPacket::initialize_packet(TypeCode::AccountingRequest)
     }
 
     /// Creates RADIUS CoA Request packet without attributes
     ///
     /// You would need to set attributes manually via *set_attributes()* function
     pub fn create_coa_packet(&self) -> RadiusPacket {
-        RadiusPacket::initialise_packet(TypeCode::CoARequest)
+        RadiusPacket::initialize_packet(TypeCode::CoARequest)
     }
 
     /// Creates RADIUS packet attribute by name, that is defined in dictionary file
@@ -212,8 +212,8 @@ impl Client {
     }
 
     /// Initialises RadiusPacket from bytes
-    pub fn initialise_packet_from_bytes(&self, reply: &[u8]) -> Result<RadiusPacket, RadiusError> {
-        self.host.initialise_packet_from_bytes(reply)
+    pub fn initialize_packet_from_bytes(&self, reply: &[u8]) -> Result<RadiusPacket, RadiusError> {
+        self.host.initialize_packet_from_bytes(reply)
     }
 
     /// Verifies that reply packet's ID and authenticator are a match
@@ -353,7 +353,7 @@ mod tests {
 
         let authenticator     = vec![215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73];
         let reply             = vec![];
-        let mut radius_packet = RadiusPacket::initialise_packet(TypeCode::AccountingRequest);
+        let mut radius_packet = RadiusPacket::initialize_packet(TypeCode::AccountingRequest);
 
         radius_packet.set_attributes(attributes);
         radius_packet.override_id(43);
@@ -381,7 +381,7 @@ mod tests {
 
         let authenticator     = vec![215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73];
         let reply             = vec![43, 215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73];
-        let mut radius_packet = RadiusPacket::initialise_packet(TypeCode::AccountingRequest);
+        let mut radius_packet = RadiusPacket::initialize_packet(TypeCode::AccountingRequest);
 
         radius_packet.set_attributes(attributes);
         radius_packet.override_id(43);
@@ -400,7 +400,7 @@ mod tests {
         let attributes    = vec![ RadiusAttribute::create_by_name(&dictionary, "User-Name", String::from("testing").into_bytes()).unwrap() ];
 
         let reply             = vec![2, 220, 0, 52, 165, 196, 239, 87, 197, 230, 219, 74, 148, 177, 209, 155, 35, 36, 236, 63, 6, 6, 0, 0, 0, 2, 8, 6, 192, 168, 0, 1, 97, 20, 0, 64, 252, 102, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
-        let mut radius_packet = RadiusPacket::initialise_packet(TypeCode::AccessRequest);
+        let mut radius_packet = RadiusPacket::initialize_packet(TypeCode::AccessRequest);
         radius_packet.set_attributes(attributes);
         radius_packet.override_id(220);
         radius_packet.override_authenticator(authenticator);
@@ -431,7 +431,7 @@ mod tests {
             RadiusAttribute::create_by_name(&dictionary, "Message-Authenticator", [0;16].to_vec()).unwrap()
         ];
 
-        let mut radius_packet = RadiusPacket::initialise_packet(TypeCode::AccessRequest);
+        let mut radius_packet = RadiusPacket::initialize_packet(TypeCode::AccessRequest);
         radius_packet.set_attributes(attributes);
         radius_packet.override_id(220);
         radius_packet.override_authenticator(authenticator);

--- a/src/protocol/host.rs
+++ b/src/protocol/host.rs
@@ -45,7 +45,7 @@ impl Host{
 
     #[allow(dead_code)]
     /// Initialises host instance with all required fields
-    pub fn initialise_host(auth_port: u16, acct_port: u16, coa_port: u16, dictionary: Dictionary) -> Host {
+    pub fn initialize_host(auth_port: u16, acct_port: u16, coa_port: u16, dictionary: Dictionary) -> Host {
         Host { auth_port, acct_port, coa_port, dictionary }
     }
 
@@ -93,8 +93,8 @@ impl Host{
     }
 
     /// Initialises RadiusPacket from bytes
-    pub fn initialise_packet_from_bytes(&self, packet: &[u8]) -> Result<RadiusPacket, RadiusError> {
-        RadiusPacket::initialise_packet_from_bytes(&self.dictionary, packet)
+    pub fn initialize_packet_from_bytes(&self, packet: &[u8]) -> Result<RadiusPacket, RadiusError> {
+        RadiusPacket::initialize_packet_from_bytes(&self.dictionary, packet)
     }
 
     /// Verifies that RadiusPacket attributes have valid values
@@ -102,7 +102,7 @@ impl Host{
     /// Note: doesn't verify Message-Authenticator attribute, because it is HMAC-MD5 hash, not an
     /// ASCII string
     pub fn verify_packet_attributes(&self, packet: &[u8]) -> Result<(), RadiusError> {
-        let _packet_tmp = RadiusPacket::initialise_packet_from_bytes(&self.dictionary, &packet)?;
+        let _packet_tmp = RadiusPacket::initialize_packet_from_bytes(&self.dictionary, &packet)?;
 
         for packet_attr in _packet_tmp.attributes().iter().filter(|&attr| attr.name() != IGNORE_VERIFY_ATTRIBUTE) {
             match self.dictionary_attribute_by_id(packet_attr.id()) {
@@ -122,7 +122,7 @@ impl Host{
     /// Verifies Message-Authenticator value
     pub fn verify_message_authenticator(&self, secret: &str, packet: &[u8]) -> Result<(), RadiusError> {
         // Step 1. Get Message-Authenticator from packet
-        let mut _packet_tmp   = RadiusPacket::initialise_packet_from_bytes(&self.dictionary, &packet)?;
+        let mut _packet_tmp   = RadiusPacket::initialize_packet_from_bytes(&self.dictionary, &packet)?;
         let original_msg_auth = _packet_tmp.message_authenticator()?.to_vec();
 
         // Step 2. Set Message-Authenticator in packet to [0; 16]
@@ -150,7 +150,7 @@ mod tests {
     #[test]
     fn test_get_dictionary_value_by_attr_and_value_name() {
         let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-        let host       = Host::initialise_host(1812, 1813, 3799, dictionary);
+        let host       = Host::initialize_host(1812, 1813, 3799, dictionary);
 
         let dict_value = host.dictionary_value_by_attr_and_value_name("Service-Type", "Login-User").unwrap();
 
@@ -162,7 +162,7 @@ mod tests {
     #[test]
     fn test_get_dictionary_value_by_attr_and_value_name_error() {
         let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-        let host       = Host::initialise_host(1812, 1813, 3799, dictionary);
+        let host       = Host::initialize_host(1812, 1813, 3799, dictionary);
 
         let dict_value = host.dictionary_value_by_attr_and_value_name("Service-Type", "Lin-User");
         assert_eq!(None, dict_value);
@@ -171,7 +171,7 @@ mod tests {
     #[test]
     fn test_get_dictionary_attribute_by_id() {
         let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-        let host       = Host::initialise_host(1812, 1813, 3799, dictionary);
+        let host       = Host::initialize_host(1812, 1813, 3799, dictionary);
 
         let dict_attr = host.dictionary_attribute_by_id(80).unwrap();
 
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn test_get_dictionary_attribute_by_id_error() {
         let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-        let host       = Host::initialise_host(1812, 1813, 3799, dictionary);
+        let host       = Host::initialize_host(1812, 1813, 3799, dictionary);
 
         let dict_attr = host.dictionary_attribute_by_id(255);
         assert_eq!(None, dict_attr);
@@ -192,7 +192,7 @@ mod tests {
     #[test]
     fn test_verify_packet_attributes() {
         let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-        let host       = Host::initialise_host(1812, 1813, 3799, dictionary);
+        let host       = Host::initialize_host(1812, 1813, 3799, dictionary);
 
         let packet_bytes = [4, 43, 0, 83, 215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73, 4, 6, 192, 168, 1, 10, 5, 6, 0, 0, 0, 0, 32, 10, 116, 114, 105, 108, 108, 105, 97, 110, 30, 19, 48, 48, 45, 48, 52, 45, 53, 70, 45, 48, 48, 45, 48, 70, 45, 68, 49, 31, 19, 48, 48, 45, 48, 49, 45, 50, 52, 45, 56, 48, 45, 66, 51, 45, 57, 67, 8, 6, 10, 0, 0, 100];
 
@@ -207,7 +207,7 @@ mod tests {
     #[test]
     fn test_verify_packet_attributes_fail() {
         let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-        let host       = Host::initialise_host(1812, 1813, 3799, dictionary);
+        let host       = Host::initialize_host(1812, 1813, 3799, dictionary);
 
         let packet_bytes = [4, 43, 0, 82, 215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73, 4, 5, 192, 168, 10, 5, 6, 0, 0, 0, 0, 32, 10, 116, 114, 105, 108, 108, 105, 97, 110, 30, 19, 48, 48, 45, 48, 52, 45, 53, 70, 45, 48, 48, 45, 48, 70, 45, 68, 49, 31, 19, 48, 48, 45, 48, 49, 45, 50, 52, 45, 56, 48, 45, 66, 51, 45, 57, 67, 8, 6, 10, 0, 0, 100];
 
@@ -222,7 +222,7 @@ mod tests {
     #[test]
     fn test_verify_message_authenticator_valid() {
         let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-        let host       = Host::initialise_host(1812, 1813, 3799, dictionary);
+        let host       = Host::initialize_host(1812, 1813, 3799, dictionary);
         let secret     = "secret";
 
         let packet_bytes = [1, 120, 0, 185, 49, 79, 108, 150, 27, 203, 166, 51, 193, 68, 15, 76, 208, 114, 171, 48, 1, 9, 116, 101, 115, 116, 105, 110, 103, 80, 18, 164, 201, 132, 0, 209, 101, 200, 189, 252, 251, 120, 224, 74, 190, 232, 197, 2, 66, 85, 125, 163, 190, 40, 210, 235, 231, 112, 96, 7, 94, 27, 95, 241, 63, 23, 81, 25, 136, 36, 209, 238, 119, 131, 113, 118, 14, 160, 16, 94, 184, 143, 37, 193, 138, 124, 238, 85, 197, 21, 17, 206, 158, 87, 132, 239, 59, 82, 183, 175, 54, 124, 138, 5, 245, 166, 195, 181, 106, 41, 31, 129, 183, 4, 6, 192, 168, 1, 10, 5, 6, 0, 0, 0, 0, 6, 6, 0, 0, 0, 2, 32, 10, 116, 114, 105, 108, 108, 105, 97, 110, 30, 19, 48, 48, 45, 48, 52, 45, 53, 70, 45, 48, 48, 45, 48, 70, 45, 68, 49, 31, 19, 48, 48, 45, 48, 49, 45, 50, 52, 45, 56, 48, 45, 66, 51, 45, 57, 67, 8, 6, 10, 0, 0, 100];
@@ -238,7 +238,7 @@ mod tests {
     #[test]
     fn test_verify_message_authenticator_wo_authenticator() {
         let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-        let host       = Host::initialise_host(1812, 1813, 3799, dictionary);
+        let host       = Host::initialize_host(1812, 1813, 3799, dictionary);
         let secret     = "secret";
 
         let packet_bytes = [4, 43, 0, 83, 215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73, 4, 6, 192, 168, 1, 10, 5, 6, 0, 0, 0, 0, 32, 10, 116, 114, 105, 108, 108, 105, 97, 110, 30, 19, 48, 48, 45, 48, 52, 45, 53, 70, 45, 48, 48, 45, 48, 70, 45, 68, 49, 31, 19, 48, 48, 45, 48, 49, 45, 50, 52, 45, 56, 48, 45, 66, 51, 45, 57, 67, 8, 6, 10, 0, 0, 100];
@@ -254,7 +254,7 @@ mod tests {
     #[test]
     fn test_verify_message_authenticator_invalid() {
         let dictionary = Dictionary::from_file("./dict_examples/integration_dict").unwrap();
-        let host       = Host::initialise_host(1812, 1813, 3799, dictionary);
+        let host       = Host::initialize_host(1812, 1813, 3799, dictionary);
         let secret     = "secret";
 
         let packet_bytes = [1, 94, 0, 190, 241, 228, 181, 142, 185, 194, 157, 205, 159, 0, 91, 199, 171, 119, 68, 44, 1, 9, 116, 101, 115, 116, 105, 110, 103, 80, 23, 109, 101, 115, 115, 97, 103, 101, 45, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 111, 114, 2, 66, 167, 81, 185, 84, 173, 104, 91, 10, 145, 109, 156, 169, 227, 109, 100, 76, 86, 227, 61, 253, 129, 35, 109, 115, 54, 140, 66, 106, 193, 70, 145, 39, 106, 105, 142, 215, 21, 166, 142, 80, 145, 217, 202, 252, 172, 33, 17, 12, 159, 105, 157, 144, 221, 221, 94, 48, 158, 22, 62, 191, 16, 177, 137, 131, 4, 6, 192, 168, 1, 10, 5, 6, 0, 0, 0, 0, 6, 6, 0, 0, 0, 2, 32, 10, 116, 114, 105, 108, 108, 105, 97, 110, 30, 19, 48, 48, 45, 48, 52, 45, 53, 70, 45, 48, 48, 45, 48, 70, 45, 68, 49, 31, 19, 48, 48, 45, 48, 49, 45, 50, 52, 45, 56, 48, 45, 66, 51, 45, 57, 67, 8, 6, 10, 0, 0, 100];

--- a/src/protocol/radius_packet.rs
+++ b/src/protocol/radius_packet.rs
@@ -344,7 +344,7 @@ pub struct RadiusPacket {
 
 impl RadiusPacket {
     /// Initialises RADIUS packet with random ID and authenticator
-    pub fn initialise_packet(code: TypeCode) -> RadiusPacket {
+    pub fn initialize_packet(code: TypeCode) -> RadiusPacket {
         RadiusPacket {
             id:            RadiusPacket::create_id(),
             code,
@@ -354,7 +354,7 @@ impl RadiusPacket {
     }
 
     /// Initialises RADIUS packet from raw bytes
-    pub fn initialise_packet_from_bytes(dictionary: &Dictionary, bytes: &[u8]) -> Result<RadiusPacket, RadiusError> {
+    pub fn initialize_packet_from_bytes(dictionary: &Dictionary, bytes: &[u8]) -> Result<RadiusPacket, RadiusError> {
         let code           = TypeCode::from_u8(bytes[0])?;
         let id             = bytes[1];
         let authenticator  = bytes[4..20].to_vec();
@@ -573,7 +573,7 @@ mod tests {
 
 
     #[test]
-    fn test_initialise_packet_from_bytes() {
+    fn test_initialize_packet_from_bytes() {
         let dictionary_path = "./dict_examples/integration_dict";
         let dict            = Dictionary::from_file(dictionary_path).unwrap();
 
@@ -588,13 +588,13 @@ mod tests {
             RadiusAttribute::create_by_name(&dict, "Framed-IP-Address",  framed_ip_addr_bytes).unwrap()
         ];
         let authenticator       = vec![215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73];
-        let mut expected_packet = RadiusPacket::initialise_packet(TypeCode::AccountingRequest);
+        let mut expected_packet = RadiusPacket::initialize_packet(TypeCode::AccountingRequest);
         expected_packet.set_attributes(attributes);
         expected_packet.override_id(43);
         expected_packet.override_authenticator(authenticator);
 
         let bytes             = [4, 43, 0, 83, 215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73, 4, 6, 192, 168, 1, 10, 5, 6, 0, 0, 0, 0, 32, 10, 116, 114, 105, 108, 108, 105, 97, 110, 30, 19, 48, 48, 45, 48, 52, 45, 53, 70, 45, 48, 48, 45, 48, 70, 45, 68, 49, 31, 19, 48, 48, 45, 48, 49, 45, 50, 52, 45, 56, 48, 45, 66, 51, 45, 57, 67, 8, 6, 10, 0, 0, 100];
-        let packet_from_bytes = RadiusPacket::initialise_packet_from_bytes(&dict, &bytes).unwrap();
+        let packet_from_bytes = RadiusPacket::initialize_packet_from_bytes(&dict, &bytes).unwrap();
 
         assert_eq!(expected_packet, packet_from_bytes);
     }
@@ -604,7 +604,7 @@ mod tests {
         let attributes: Vec<RadiusAttribute> = Vec::with_capacity(1);
         let new_id: u8                       = 50;
 
-        let mut packet = RadiusPacket::initialise_packet(TypeCode::AccessRequest);
+        let mut packet = RadiusPacket::initialize_packet(TypeCode::AccessRequest);
         packet.set_attributes(attributes);
         packet.override_id(new_id);
 
@@ -615,7 +615,7 @@ mod tests {
         let attributes: Vec<RadiusAttribute> = Vec::with_capacity(1);
         let new_authenticator: Vec<u8>       = vec![0, 25, 100, 56, 13];
 
-        let mut packet = RadiusPacket::initialise_packet(TypeCode::AccessRequest);
+        let mut packet = RadiusPacket::initialize_packet(TypeCode::AccessRequest);
         packet.set_attributes(attributes);
         packet.override_authenticator(new_authenticator.to_vec());
 
@@ -628,7 +628,7 @@ mod tests {
         let new_authenticator: Vec<u8>       = vec![0, 25, 100, 56, 13, 0, 67, 34, 39, 12, 88, 153, 0, 1, 2, 3];
 
         let exepcted_bytes = vec![1, 50, 0, 20, 0, 25, 100, 56, 13, 0, 67, 34, 39, 12, 88, 153, 0, 1, 2, 3];
-        let mut packet = RadiusPacket::initialise_packet(TypeCode::AccessRequest);
+        let mut packet = RadiusPacket::initialize_packet(TypeCode::AccessRequest);
         packet.set_attributes(attributes);
         packet.override_id(new_id);
         packet.override_authenticator(new_authenticator);
@@ -653,7 +653,7 @@ mod tests {
         ];
 
         let new_message_authenticator = vec![1, 50, 0, 20, 0, 25, 100, 56, 13, 0, 67, 34, 39, 12, 88, 153];
-        let mut packet = RadiusPacket::initialise_packet(TypeCode::AccountingRequest);
+        let mut packet = RadiusPacket::initialize_packet(TypeCode::AccountingRequest);
         packet.set_attributes(attributes);
 
         match packet.override_message_authenticator(new_message_authenticator) {
@@ -672,7 +672,7 @@ mod tests {
             RadiusAttribute::create_by_name(&dict, "Message-Authenticator", vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap()
         ];
 
-        let mut packet                 = RadiusPacket::initialise_packet(TypeCode::AccessRequest);
+        let mut packet                 = RadiusPacket::initialize_packet(TypeCode::AccessRequest);
         let new_message_authenticator  = vec![1, 50, 0, 20, 0, 25, 100, 56, 13, 0, 67, 34, 39, 12, 88, 153];
         let new_id: u8                 = 50;
         let new_authenticator: Vec<u8> = vec![0, 25, 100, 56, 13, 0, 67, 34, 39, 12, 88, 153, 0, 1, 2, 3];
@@ -696,7 +696,7 @@ mod tests {
         let dictionary_path = "./dict_examples/integration_dict";
         let dict            = Dictionary::from_file(dictionary_path).unwrap();
         let secret          = "secret";
-        let mut packet      = RadiusPacket::initialise_packet(TypeCode::AccessRequest);
+        let mut packet      = RadiusPacket::initialize_packet(TypeCode::AccessRequest);
 
         let attributes        = vec![
             RadiusAttribute::create_by_name(&dict, "User-Name",             String::from("testing").into_bytes()).unwrap(),

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -130,7 +130,7 @@ impl Server {
     ///
     /// Similar to [Client's create_packet()](crate::client::client::Client::create_packet), however also sets correct packet ID and authenticator
     pub fn create_reply_packet(&self, reply_code: TypeCode, attributes: Vec<RadiusAttribute>, request: &mut [u8]) -> RadiusPacket {
-        let mut reply_packet = RadiusPacket::initialise_packet(reply_code);
+        let mut reply_packet = RadiusPacket::initialize_packet(reply_code);
         reply_packet.set_attributes(attributes);
 
         // We can only create new authenticator after we set reply packet ID to the request's ID
@@ -160,7 +160,7 @@ impl Server {
     /// Server would try to build RadiusPacket from raw bytes, and if it succeeds then packet is
     /// valid, otherwise would return RadiusError
     pub fn verify_request(&self, request: &[u8]) -> Result<(), RadiusError> {
-        match RadiusPacket::initialise_packet_from_bytes(&self.host.dictionary(), request) {
+        match RadiusPacket::initialize_packet_from_bytes(&self.host.dictionary(), request) {
             Err(err) => Err(err),
             _        => Ok(())
         }
@@ -178,8 +178,8 @@ impl Server {
     ///
     /// Unlike [verify_request](Server::verify_request), on success this function would return
     /// RadiusPacket
-    pub fn initialise_packet_from_bytes(&self, request: &[u8]) -> Result<RadiusPacket, RadiusError> {
-        self.host.initialise_packet_from_bytes(request)
+    pub fn initialize_packet_from_bytes(&self, request: &[u8]) -> Result<RadiusPacket, RadiusError> {
+        self.host.initialize_packet_from_bytes(request)
     }
 
     /// Checks if host from where Server received RADIUS request is allowed host, meaning RADIUS


### PR DESCRIPTION
Please note that the proper spelling of initialize is with a 'z' instead of an 's'.

At present, the misspelling of "initialize" is in...

- `src/protocol/host.rs` 
- `src/client/client.rs`
- `src/server/server.rs`
- `src/protocol/radius_packet.rs`
- `tests/test_async_client.rs`
- `tests/test_client.rs`
- `benches/sync_client_2_server.rs`
- `benches/async_client_2_server.rs`
- `examples/*.rs`

This PR corrects the spelling errors of "initialize".